### PR TITLE
Appointment-Reduce number of mandatory fields

### DIFF
--- a/Orso.Arpa.Application/AppointmentApplication/AppointmentCreateDto.cs
+++ b/Orso.Arpa.Application/AppointmentApplication/AppointmentCreateDto.cs
@@ -31,13 +31,9 @@ namespace Orso.Arpa.Application.AppointmentApplication
     {
         public AppointmentCreateDtoValidator()
         {
-            
+
             RuleFor(d => d)
                 .NotNull();
-            RuleFor(d => d.CategoryId)
-                .NotEmpty();
-            RuleFor(d => d.StatusId)
-                .NotEmpty();
             RuleFor(d => d.StartTime)
                 .NotEmpty();
             RuleFor(d => d.EndTime)
@@ -51,8 +47,6 @@ namespace Orso.Arpa.Application.AppointmentApplication
                 .MaximumLength(1000);
             RuleFor(d => d.PublicDetails)
                 .MaximumLength(1000);
-            RuleFor(d => d.EmolumentId)
-                .NotEmpty();
         }
     }
 }

--- a/Orso.Arpa.Application/AppointmentApplication/AppointmentModifyDto.cs
+++ b/Orso.Arpa.Application/AppointmentApplication/AppointmentModifyDto.cs
@@ -34,14 +34,10 @@ namespace Orso.Arpa.Application.AppointmentApplication
     {
         public AppointmentModifyDtoValidator()
         {
-            
+
             RuleFor(d => d)
                 .NotNull();
             RuleFor(d => d.Id)
-                .NotEmpty();
-            RuleFor(d => d.CategoryId)
-                .NotEmpty();
-            RuleFor(d => d.StatusId)
                 .NotEmpty();
             RuleFor(d => d.StartTime)
                 .NotEmpty();
@@ -56,8 +52,6 @@ namespace Orso.Arpa.Application.AppointmentApplication
                 .MaximumLength(1000);
             RuleFor(d => d.PublicDetails)
                 .MaximumLength(1000);
-            RuleFor(d => d.EmolumentId)
-                .NotEmpty();
         }
     }
 }

--- a/Tests/Orso.Arpa.Api.Tests/IntegrationTests/AppointmentsControllerTests.cs
+++ b/Tests/Orso.Arpa.Api.Tests/IntegrationTests/AppointmentsControllerTests.cs
@@ -27,18 +27,18 @@ namespace Orso.Arpa.Api.Tests.IntegrationTests
         public async Task Should_Get_Appointments()
         {
             // Act
-                HttpResponseMessage responseMessage = await _authenticatedServer
-                .CreateClient()
-                .AuthenticateWith(_performer)
-                .GetAsync(ApiEndpoints.AppointmentsController.Get(new DateTime(2019, 12, 21), DateRange.Day));
-                AppointmentDto expectedDto = AppointmentDtoData.RockingXMasRehearsal;
+            HttpResponseMessage responseMessage = await _authenticatedServer
+            .CreateClient()
+            .AuthenticateWith(_performer)
+            .GetAsync(ApiEndpoints.AppointmentsController.Get(new DateTime(2019, 12, 21), DateRange.Day));
+            AppointmentDto expectedDto = AppointmentDtoData.RockingXMasRehearsal;
 
-                // Assert
-                responseMessage.StatusCode.Should().Be(HttpStatusCode.OK);
-                IEnumerable<AppointmentDto> result = await DeserializeResponseMessageAsync<IEnumerable<AppointmentDto>>(responseMessage);
-                result.Count().Should().Be(1);
-                AppointmentDto returnedAppointment = result.First();
-                returnedAppointment.Should().BeEquivalentTo(expectedDto);
+            // Assert
+            responseMessage.StatusCode.Should().Be(HttpStatusCode.OK);
+            IEnumerable<AppointmentDto> result = await DeserializeResponseMessageAsync<IEnumerable<AppointmentDto>>(responseMessage);
+            result.Count().Should().Be(1);
+            AppointmentDto returnedAppointment = result.First();
+            returnedAppointment.Should().BeEquivalentTo(expectedDto);
         }
 
         [Test, Order(2)]
@@ -68,12 +68,8 @@ namespace Orso.Arpa.Api.Tests.IntegrationTests
                 Name = "New Appointment",
                 InternalDetails = "Internal Details",
                 PublicDetails = "Public Details",
-                CategoryId = SelectValueMappingSeedData.AppointmentCategoryMappings[0].Id,
-                EmolumentId = SelectValueMappingSeedData.AppointmentEmolumentMappings[0].Id,
-                EmolumentPatternId = SelectValueMappingSeedData.AppointmentEmolumentPatternMappings[0].Id,
                 EndTime = new DateTime(2021, 3, 5, 14, 15, 20),
-                StartTime = new DateTime(2021,3,5,9,15,20),
-                StatusId = SelectValueMappingSeedData.AppointmentStatusMappings[0].Id
+                StartTime = new DateTime(2021, 3, 5, 9, 15, 20),
             };
 
             var expectedDto = new AppointmentDto
@@ -85,9 +81,6 @@ namespace Orso.Arpa.Api.Tests.IntegrationTests
                 ModifiedBy = null,
                 InternalDetails = createDto.InternalDetails,
                 PublicDetails = createDto.PublicDetails,
-                CategoryId = createDto.CategoryId,
-                EmolumentId = createDto.EmolumentId,
-                EmolumentPatternId = createDto.EmolumentPatternId,
                 EndTime = createDto.EndTime,
                 StartTime = createDto.StartTime,
                 StatusId = createDto.StatusId
@@ -224,6 +217,30 @@ namespace Orso.Arpa.Api.Tests.IntegrationTests
                 EndTime = DateTimeProvider.Instance.GetUtcNow().AddHours(5),
                 StartTime = DateTimeProvider.Instance.GetUtcNow(),
                 StatusId = SelectValueMappingSeedData.AppointmentStatusMappings[0].Id
+            };
+
+            // Act
+            HttpResponseMessage responseMessage = await _authenticatedServer
+                .CreateClient()
+                .AuthenticateWith(_staff)
+                .PutAsync(ApiEndpoints.AppointmentsController.Put(appointmentToModify.Id), BuildStringContent(modifyDto));
+
+            // Assert
+            responseMessage.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        }
+        [Test, Order(108)]
+        public async Task Should_Modify_With_Only_Mandatory_Fields_Specified()
+        {
+            // Arrange
+            Appointment appointmentToModify = AppointmentSeedData.RockingXMasConcert;
+
+            var modifyDto = new AppointmentModifyDto
+            {
+                Name = "New Appointment",
+                InternalDetails = "Internal Details",
+                PublicDetails = "Public Details",
+                EndTime = DateTimeProvider.Instance.GetUtcNow().AddHours(5),
+                StartTime = DateTimeProvider.Instance.GetUtcNow(),
             };
 
             // Act

--- a/Tests/Orso.Arpa.Application.Tests/ValidationTests/AppointmentCreateDtoValidatorTests.cs
+++ b/Tests/Orso.Arpa.Application.Tests/ValidationTests/AppointmentCreateDtoValidatorTests.cs
@@ -18,9 +18,9 @@ namespace Orso.Arpa.Application.Tests.ValidationTests
         private AppointmentCreateDtoValidator _validator;
 
         [Test]
-        public void Should_Have_Validation_Error_If_Empty_CategoryId_Is_Supplied()
+        public void Should_Not_Have_Validation_Error_If_Empty_CategoryId_Is_Supplied()
         {
-            _validator.ShouldHaveValidationErrorFor(command => command.CategoryId, default(Guid?));
+            _validator.ShouldNotHaveValidationErrorFor(command => command.CategoryId, default(Guid?));
         }
 
         [Test]
@@ -30,9 +30,9 @@ namespace Orso.Arpa.Application.Tests.ValidationTests
         }
 
         [Test]
-        public void Should_Have_Validation_Error_If_Empty_StatusId_Is_Supplied()
+        public void Should_Not_Have_Validation_Error_If_Empty_StatusId_Is_Supplied()
         {
-            _validator.ShouldHaveValidationErrorFor(command => command.StatusId, default(Guid?));
+            _validator.ShouldNotHaveValidationErrorFor(command => command.StatusId, default(Guid?));
         }
 
         [Test]
@@ -42,9 +42,9 @@ namespace Orso.Arpa.Application.Tests.ValidationTests
         }
 
         [Test]
-        public void Should_Have_Validation_Error_If_Empty_EmolumentId_Is_Supplied()
+        public void Should_Not_Have_Validation_Error_If_Empty_EmolumentId_Is_Supplied()
         {
-            _validator.ShouldHaveValidationErrorFor(command => command.EmolumentId, default(Guid?));
+            _validator.ShouldNotHaveValidationErrorFor(command => command.EmolumentId, default(Guid?));
         }
 
         [Test]
@@ -108,7 +108,7 @@ namespace Orso.Arpa.Application.Tests.ValidationTests
         }
 
         [Test]
-        public void Should_Have_Validation_Error_If_Empty_Name_Is_Supplied([Values(null, "")]string name)
+        public void Should_Have_Validation_Error_If_Empty_Name_Is_Supplied([Values(null, "")] string name)
         {
             _validator.ShouldHaveValidationErrorFor(command => command.Name, name);
         }

--- a/Tests/Orso.Arpa.Application.Tests/ValidationTests/AppointmentModifyDtoValidatorTests.cs
+++ b/Tests/Orso.Arpa.Application.Tests/ValidationTests/AppointmentModifyDtoValidatorTests.cs
@@ -30,9 +30,9 @@ namespace Orso.Arpa.Application.Tests.ValidationTests
         }
 
         [Test]
-        public void Should_Have_Validation_Error_If_Empty_CategoryId_Is_Supplied()
+        public void Should_Not_Have_Validation_Error_If_Empty_CategoryId_Is_Supplied()
         {
-            _validator.ShouldHaveValidationErrorFor(command => command.CategoryId, default(Guid?));
+            _validator.ShouldNotHaveValidationErrorFor(command => command.CategoryId, default(Guid?));
         }
 
         [Test]
@@ -42,9 +42,9 @@ namespace Orso.Arpa.Application.Tests.ValidationTests
         }
 
         [Test]
-        public void Should_Have_Validation_Error_If_Empty_StatusId_Is_Supplied()
+        public void Should_Not_Have_Validation_Error_If_Empty_StatusId_Is_Supplied()
         {
-            _validator.ShouldHaveValidationErrorFor(command => command.StatusId, default(Guid?));
+            _validator.ShouldNotHaveValidationErrorFor(command => command.StatusId, default(Guid?));
         }
 
         [Test]
@@ -54,9 +54,9 @@ namespace Orso.Arpa.Application.Tests.ValidationTests
         }
 
         [Test]
-        public void Should_Have_Validation_Error_If_Empty_EmolumentId_Is_Supplied()
+        public void Should_Not_Have_Validation_Error_If_Empty_EmolumentId_Is_Supplied()
         {
-            _validator.ShouldHaveValidationErrorFor(command => command.EmolumentId, default(Guid?));
+            _validator.ShouldNotHaveValidationErrorFor(command => command.EmolumentId, default(Guid?));
         }
 
         [Test]
@@ -120,7 +120,7 @@ namespace Orso.Arpa.Application.Tests.ValidationTests
         }
 
         [Test]
-        public void Should_Have_Validation_Error_If_Empty_Name_Is_Supplied([Values(null, "")]string name)
+        public void Should_Have_Validation_Error_If_Empty_Name_Is_Supplied([Values(null, "")] string name)
         {
             _validator.ShouldHaveValidationErrorFor(command => command.Name, name);
         }


### PR DESCRIPTION
Fields `Status`, `Category`, `ExpectationId`, `EmolumentId`, `EmolumentPatternId `are no longer mandatory fields