### PR TITLE
Arpa 344 support case insensitive filters

### DIFF
--- a/Orso.Arpa.Api/GraphQL/CustomFilteringConvention.cs
+++ b/Orso.Arpa.Api/GraphQL/CustomFilteringConvention.cs
@@ -12,7 +12,8 @@ namespace Orso.Arpa.Api.GraphQL
             descriptor.Operation(DefaultFilterOperations.Equals).Name("equals");
             descriptor.AddProviderExtension(
                 new QueryableFilterProviderExtension(x => {
-                x.AddFieldHandler<QueryableStringInvariantEqualsHandler>();
+                x.AddFieldHandler<QueryableStringInvariantEqualsHandler>()
+                    .AddFieldHandler<QueryableStringInvariantContainsHandler>();
             }));
         }
     }

--- a/Orso.Arpa.Api/GraphQL/CustomFilteringConvention.cs
+++ b/Orso.Arpa.Api/GraphQL/CustomFilteringConvention.cs
@@ -1,0 +1,19 @@
+using HotChocolate.Data;
+using HotChocolate.Data.Filters;
+using HotChocolate.Data.Filters.Expressions;
+
+namespace Orso.Arpa.Api.GraphQL
+{
+    public class CustomFilteringConvention : FilterConvention
+    {
+        protected override void Configure(IFilterConventionDescriptor descriptor)
+        {
+            descriptor.AddDefaults();
+            descriptor.Operation(DefaultFilterOperations.Equals).Name("equals");
+            descriptor.AddProviderExtension(
+                new QueryableFilterProviderExtension(x => {
+                x.AddFieldHandler<QueryableStringInvariantEqualsHandler>();
+            }));
+        }
+    }
+}

--- a/Orso.Arpa.Api/GraphQL/QueryableStringInvariantContainsHandler.cs
+++ b/Orso.Arpa.Api/GraphQL/QueryableStringInvariantContainsHandler.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using HotChocolate.Data.Filters;
+using HotChocolate.Data.Filters.Expressions;
+using HotChocolate.Language;
+using Microsoft.EntityFrameworkCore;
+
+namespace Orso.Arpa.Api.GraphQL
+{
+    public class QueryableStringInvariantContainsHandler : QueryableStringOperationHandler
+    {
+        private static readonly MethodInfo _toLower = typeof(string)
+            .GetMethods()
+            .Single(
+                x => x.Name == nameof(string.ToLower) &&
+                x.GetParameters().Length == 0);
+
+        protected override int Operation => DefaultFilterOperations.Contains;
+
+        public override Expression HandleOperation(
+            QueryableFilterContext context,
+            IFilterOperationField field,
+            IValueNode value,
+            object? parsedValue)
+        {
+            Expression property = context.GetInstance();
+            if (parsedValue is string str)
+            {
+                // Bad way of doing it but Using ILIKE on DB level is somehow not working.
+                // https://github.com/npgsql/efcore.pg/issues/618
+                return Expression.NotEqual(
+                    Expression.Call(
+                        property,
+                        typeof(string).GetMethod("IndexOf", new[] { typeof(string), typeof(StringComparison) }),
+                        Expression.Constant(str),
+                        Expression.Constant(StringComparison.OrdinalIgnoreCase)
+                    ),
+                    Expression.Constant(-1)
+                );
+            }
+
+            throw new InvalidOperationException();
+        }
+    }
+}

--- a/Orso.Arpa.Api/GraphQL/QueryableStringInvariantEqualsHandler.cs
+++ b/Orso.Arpa.Api/GraphQL/QueryableStringInvariantEqualsHandler.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using HotChocolate.Data.Filters;
+using HotChocolate.Data.Filters.Expressions;
+using HotChocolate.Language;
+
+namespace Orso.Arpa.Api.GraphQL
+{
+    public class QueryableStringInvariantEqualsHandler : QueryableStringOperationHandler
+    {
+        private static readonly MethodInfo _toLower = typeof(string)
+            .GetMethods()
+            .Single(
+                x => x.Name == nameof(string.ToLower) &&
+                     x.GetParameters().Length == 0);
+
+        protected override int Operation => DefaultFilterOperations.Equals;
+
+        public override Expression HandleOperation(
+            QueryableFilterContext context,
+            IFilterOperationField field,
+            IValueNode value,
+            object parsedValue)
+        {
+            Expression property = context.GetInstance();
+            if (parsedValue is string str)
+            {
+                return Expression.Equal(
+                    Expression.Call(property, _toLower),
+                    Expression.Constant(str.ToLower()));
+            }
+
+            throw new InvalidOperationException();
+        }
+    }
+}

--- a/Orso.Arpa.Api/Startup.cs
+++ b/Orso.Arpa.Api/Startup.cs
@@ -124,6 +124,7 @@ namespace Orso.Arpa.Api
             services
                 .AddGraphQLServer()
                 .AddAuthorization()
+                .AddFiltering<CustomFilteringConvention>()
                 .AddQueryType<Query>()
                 .AddFiltering()
                 .AddSorting();


### PR DESCRIPTION
To be able to search and filter on graph level we need to support not case-sensitive queries. Unfortunately, pgress is case-sensitive.